### PR TITLE
Convert inet data types to varchars

### DIFF
--- a/lib/postgres_to_redshift/column.rb
+++ b/lib/postgres_to_redshift/column.rb
@@ -55,6 +55,7 @@ class PostgresToRedshift::Column
     "oid" => "CHARACTER VARYING(65535)",
     "ARRAY" => "CHARACTER VARYING(65535)",
     "USER-DEFINED" => "CHARACTER VARYING(65535)",
+    "inet" => "CHARACTER VARYING(65535)"
   }
 
   def initialize(attributes: )


### PR DESCRIPTION
We recently added some ip address columns with a data type of `inet`. These are breaking the Redshift import.

This PR converts those data types to `CHARACTER VARYING(65535)`.