### PR TITLE
Add uuid data type as varchar(32)

### DIFF
--- a/lib/postgres_to_redshift/column.rb
+++ b/lib/postgres_to_redshift/column.rb
@@ -57,7 +57,8 @@ class PostgresToRedshift::Column
     "USER-DEFINED" => "CHARACTER VARYING(65535)",
     "inet" => "CHARACTER VARYING(65535)",
     "numeric" => "DOUBLE PRECISION",
-    "character varying" => "CHARACTER VARYING(2000)"
+    "character varying" => "CHARACTER VARYING(2000)",
+    "uuid" => "CHARACTER VARYING(32)"
   }
 
   def initialize(attributes: )


### PR DESCRIPTION
Add a conversion for `uuid` to `character varying(32)`.

The `uuid` type in Postgres is 128 bits: https://www.postgresql.org/docs/9.1/datatype-uuid.html

I'm storing them in 256 bits to have a little headroom.