### PR TITLE
Increase S3 retries to 6

### DIFF
--- a/lib/postgres_to_redshift.rb
+++ b/lib/postgres_to_redshift.rb
@@ -81,7 +81,7 @@ class PostgresToRedshift
   end
 
   def s3
-    @s3 ||= AWS::S3.new(access_key_id: ENV['S3_DATABASE_EXPORT_ID'], secret_access_key: ENV['S3_DATABASE_EXPORT_KEY'])
+    @s3 ||= AWS::S3.new(access_key_id: ENV['S3_DATABASE_EXPORT_ID'], secret_access_key: ENV['S3_DATABASE_EXPORT_KEY'], max_retries: 6)
   end
 
   def bucket

--- a/lib/postgres_to_redshift.rb
+++ b/lib/postgres_to_redshift.rb
@@ -81,7 +81,8 @@ class PostgresToRedshift
   end
 
   def s3
-    @s3 ||= AWS::S3.new(access_key_id: ENV['S3_DATABASE_EXPORT_ID'], secret_access_key: ENV['S3_DATABASE_EXPORT_KEY'], max_retries: 6)
+    max_retries_config = AWS.config.with(:max_retries => 6)
+    @s3 ||= AWS::S3.new(access_key_id: ENV['S3_DATABASE_EXPORT_ID'], secret_access_key: ENV['S3_DATABASE_EXPORT_KEY'], config: max_retries_config)
   end
 
   def bucket


### PR DESCRIPTION
We've had failures in the step that copies from S3 to Redshift with a `key not found` error.

We believe this is because of S3's eventual consistency data model — sometimes the data is not fully available on the machine being read from, so the pipeline fails.

This PR bumps up the max retries to 6.