### PR TITLE
Add a pause and retry if copying from S3 fails

### DIFF
--- a/lib/postgres_to_redshift.rb
+++ b/lib/postgres_to_redshift.rb
@@ -154,6 +154,7 @@ class PostgresToRedshift
       puts "COPY failed. Pausing for #{SLEEP_IN_SECONDS} seconds."
       sleep SLEEP_IN_SECONDS
       target_connection.exec("COPY #{schema}.#{target_connection.quote_ident(table.target_table_name)} FROM 's3://#{ENV['S3_DATABASE_EXPORT_BUCKET']}/export/#{table.target_table_name}.psv.gz' CREDENTIALS 'aws_access_key_id=#{ENV['S3_DATABASE_EXPORT_ID']};aws_secret_access_key=#{ENV['S3_DATABASE_EXPORT_KEY']}' GZIP TRUNCATECOLUMNS ESCAPE DELIMITER as '|';")
+    end
 
     target_connection.exec("DROP TABLE IF EXISTS #{schema}.#{table.target_table_name}_updating CASCADE")
 


### PR DESCRIPTION
We've continued to see the following failures when copying from S3 into Redshift:

```error:  S3ServiceException:The specified key does not exist.,Status 404,Error NoSuchKey```

It's possible that the read is happening before the data is consistently available. To test this hypothesis, this PR adds a pause and retry if the copy command fails.